### PR TITLE
[15] Multi-platform output: standard templates for common platforms

### DIFF
--- a/code/apps/api/src/platform-templates/templates.ts
+++ b/code/apps/api/src/platform-templates/templates.ts
@@ -1,0 +1,68 @@
+export interface PlatformTemplate {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  widthPx: number;
+  heightPx: number;
+  fields: string[];
+  html: string;
+}
+
+export const platformTemplates: PlatformTemplate[] = [
+  {
+    id: "linkedin-banner",
+    name: "LinkedIn Banner",
+    description:
+      "Professional banner for your LinkedIn profile. Features your logo, company name, tagline, and a call-to-action.",
+    category: "Social Media",
+    widthPx: 1200,
+    heightPx: 630,
+    fields: ["headline", "ctaText"],
+    html: `<!DOCTYPE html><html><head><meta charset="utf-8"><style>html,body{margin:0;padding:0;}.banner{width:1200px;height:630px;background-color:{{ profile.brandColors.primary }};display:flex;flex-direction:column;box-sizing:border-box;padding:48px 64px;font-family:'Segoe UI',sans-serif;color:#ffffff;}.top{display:flex;align-items:center;}.logo{height:56px;border-radius:8px;}.spacer{flex:1;}.company{font-size:22px;opacity:.85;}.center{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;}.headline{font-size:72px;font-weight:800;margin:0;line-height:1.05;text-shadow:0 2px 8px rgba(0,0,0,.25);}.tagline{font-size:30px;margin-top:18px;opacity:.9;}.cta{margin-top:40px;background-color:{{ profile.brandColors.secondary }};color:#111827;font-size:26px;font-weight:700;padding:16px 40px;border-radius:9999px;}</style></head><body><div class="banner"><div class="top"><img class="logo" src="{{ profile.logo }}" alt="logo"><div class="spacer"></div><span class="company">{{ profile.displayName }}</span></div><div class="center"><h1 class="headline">{{ headline }}</h1><p class="tagline">{{ profile.tagline }}</p><div class="cta">{{ ctaText }}</div></div></div></body></html>`,
+  },
+  {
+    id: "instagram-post",
+    name: "Instagram Post",
+    description:
+      "Square post graphic for Instagram. Bold headline over a brand-colored background with your logo.",
+    category: "Social Media",
+    widthPx: 1080,
+    heightPx: 1080,
+    fields: ["headline", "subtext"],
+    html: `<!DOCTYPE html><html><head><meta charset="utf-8"><style>html,body{margin:0;padding:0;}.post{width:1080px;height:1080px;background:{{ profile.brandColors.primary }};display:flex;flex-direction:column;align-items:center;justify-content:center;box-sizing:border-box;padding:80px;font-family:'Segoe UI',sans-serif;color:#fff;text-align:center;}.logo{height:80px;border-radius:12px;margin-bottom:48px;}.headline{font-size:64px;font-weight:800;margin:0;line-height:1.1;text-shadow:0 2px 12px rgba(0,0,0,.3);}.divider{width:100px;height:6px;background:{{ profile.brandColors.secondary }};border-radius:3px;margin:36px 0;}.subtext{font-size:32px;opacity:.85;margin:0;max-width:800px;line-height:1.4;}.company{position:absolute;bottom:48px;font-size:20px;opacity:.6;letter-spacing:2px;text-transform:uppercase;}</style></head><body><div class="post" style="position:relative"><img class="logo" src="{{ profile.logo }}" alt="logo"><h1 class="headline">{{ headline }}</h1><div class="divider"></div><p class="subtext">{{ subtext }}</p><span class="company">{{ profile.displayName }}</span></div></body></html>`,
+  },
+  {
+    id: "twitter-header",
+    name: "Twitter / X Header",
+    description:
+      "Wide header image for your Twitter or X profile. Clean layout with logo, display name, and tagline.",
+    category: "Social Media",
+    widthPx: 1500,
+    heightPx: 500,
+    fields: ["headline"],
+    html: `<!DOCTYPE html><html><head><meta charset="utf-8"><style>html,body{margin:0;padding:0;}.header{width:1500px;height:500px;background:{{ profile.brandColors.primary }};display:flex;align-items:center;box-sizing:border-box;padding:0 120px;font-family:'Segoe UI',sans-serif;color:#fff;position:relative;overflow:hidden;}.header::after{content:"";position:absolute;right:-60px;top:-60px;width:300px;height:300px;border-radius:50%;background:{{ profile.brandColors.secondary }};opacity:.15;}.content{display:flex;align-items:center;gap:48px;z-index:1;}.logo{height:100px;width:100px;border-radius:16px;object-fit:contain;background:#fff1;}.text{}.name{font-size:48px;font-weight:800;margin:0;}.tagline{font-size:24px;opacity:.8;margin:8px 0 0 0;}.headline{font-size:28px;font-weight:600;margin-top:16px;color:{{ profile.brandColors.secondary }};}</style></head><body><div class="header"><div class="content"><img class="logo" src="{{ profile.logo }}" alt="logo"><div class="text"><h1 class="name">{{ profile.displayName }}</h1><p class="tagline">{{ profile.tagline }}</p><p class="headline">{{ headline }}</p></div></div></div></body></html>`,
+  },
+  {
+    id: "email-header",
+    name: "Email Header",
+    description:
+      "Compact header for email newsletters and campaigns. Logo and company name on a brand background.",
+    category: "Email",
+    widthPx: 600,
+    heightPx: 200,
+    fields: [],
+    html: `<!DOCTYPE html><html><head><meta charset="utf-8"><style>html,body{margin:0;padding:0;}.email-header{width:600px;height:200px;background:{{ profile.brandColors.primary }};display:flex;align-items:center;justify-content:space-between;box-sizing:border-box;padding:0 48px;font-family:'Segoe UI',sans-serif;color:#fff;}.left{display:flex;align-items:center;gap:20px;}.logo{height:48px;border-radius:8px;}.company{font-size:28px;font-weight:700;}.tagline{font-size:16px;opacity:.75;margin-top:4px;}.accent{width:6px;height:80px;background:{{ profile.brandColors.secondary }};border-radius:3px;}</style></head><body><div class="email-header"><div class="left"><img class="logo" src="{{ profile.logo }}" alt="logo"><div><div class="company">{{ profile.displayName }}</div><div class="tagline">{{ profile.tagline }}</div></div></div><div class="accent"></div></div></body></html>`,
+  },
+  {
+    id: "event-banner",
+    name: "Event Banner",
+    description:
+      "Promotional banner for webinars, conferences, or events. Features date, title, and brand styling.",
+    category: "Marketing",
+    widthPx: 1200,
+    heightPx: 628,
+    fields: ["eventTitle", "eventDate"],
+    html: `<!DOCTYPE html><html><head><meta charset="utf-8"><style>html,body{margin:0;padding:0;}.banner{width:1200px;height:628px;background:{{ profile.brandColors.primary }};display:flex;box-sizing:border-box;font-family:'Segoe UI',sans-serif;color:#fff;overflow:hidden;}.left{flex:1;display:flex;flex-direction:column;justify-content:center;padding:56px 64px;}.right{width:380px;background:{{ profile.brandColors.secondary }};display:flex;flex-direction:column;align-items:center;justify-content:center;position:relative;}.badge{font-size:18px;font-weight:700;text-transform:uppercase;letter-spacing:3px;opacity:.7;margin-bottom:12px;}.event-title{font-size:56px;font-weight:800;margin:0;line-height:1.1;}.event-date{font-size:28px;margin-top:24px;opacity:.85;font-weight:600;}.logo{height:48px;border-radius:8px;margin-top:32px;}.date-box{font-size:48px;font-weight:800;color:{{ profile.brandColors.primary }};text-align:center;}.month{font-size:20px;font-weight:600;text-transform:uppercase;letter-spacing:2px;margin-top:4px;}</style></head><body><div class="banner"><div class="left"><span class="badge">{{ profile.displayName }}</span><h1 class="event-title">{{ eventTitle }}</h1><p class="event-date">{{ eventDate }}</p><img class="logo" src="{{ profile.logo }}" alt="logo"></div><div class="right"><div class="date-box">{{ eventDate }}<div class="month">2025</div></div></div></div></body></html>`,
+  },
+];

--- a/code/apps/api/src/routes/api/index.ts
+++ b/code/apps/api/src/routes/api/index.ts
@@ -10,6 +10,7 @@ import userRoute from "./users"
 import setRoute from "./set"
 import aiRoute from "./ai"
 import authRoute from "./auth"
+import platformTemplatesRoute from "./platform-templates"
 
 const router:Router = Router();
 
@@ -163,5 +164,6 @@ router.use("/users", userRoute)
 router.use("/set", setRoute)
 router.use("/ai", aiRoute)
 router.use("/auth", authRoute)
+router.use("/platform-templates", platformTemplatesRoute)
 
 export default router;

--- a/code/apps/api/src/routes/api/platform-templates.ts
+++ b/code/apps/api/src/routes/api/platform-templates.ts
@@ -1,0 +1,130 @@
+import { logger } from "@repo/logger";
+import { Router } from "express";
+import { platformTemplates } from "../../platform-templates/templates.ts";
+
+const router: Router = Router();
+
+/**
+ * @openapi
+ * /api/platform-templates:
+ *   get:
+ *     summary: List platform templates
+ *     description: List all curated platform templates available for use. These are read-only reference templates.
+ *     tags: [Platform Templates]
+ *     security:
+ *       - apiKey: []
+ *     responses:
+ *       200:
+ *         description: Platform templates listed successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 templates:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id: { type: string }
+ *                       name: { type: string }
+ *                       description: { type: string }
+ *                       category: { type: string }
+ *                       widthPx: { type: integer }
+ *                       heightPx: { type: integer }
+ *                       fields: { type: array, items: { type: string } }
+ *       401:
+ *         description: Unauthorized
+ */
+router.get("/", async (_req, res) => {
+  try {
+    const userId = res.locals.user?.id;
+    if (!userId) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const summaries = platformTemplates.map(
+      ({ id, name, description, category, widthPx, heightPx, fields }) => ({
+        id,
+        name,
+        description,
+        category,
+        widthPx,
+        heightPx,
+        fields,
+      }),
+    );
+
+    return res.json({ success: true, templates: summaries });
+  } catch (error) {
+    logger.error({ error: error as Error });
+    res.status(500).json({ error: "Failed to list platform templates" });
+  }
+});
+
+/**
+ * @openapi
+ * /api/platform-templates/{id}:
+ *   get:
+ *     summary: Get platform template
+ *     description: Get the full HTML content of a curated platform template by its ID.
+ *     tags: [Platform Templates]
+ *     security:
+ *       - apiKey: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Platform template ID
+ *     responses:
+ *       200:
+ *         description: Platform template retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 template:
+ *                   type: object
+ *                   properties:
+ *                     id: { type: string }
+ *                     name: { type: string }
+ *                     description: { type: string }
+ *                     category: { type: string }
+ *                     widthPx: { type: integer }
+ *                     heightPx: { type: integer }
+ *                     fields: { type: array, items: { type: string } }
+ *                     html: { type: string }
+ *       401:
+ *         description: Unauthorized
+ *       404:
+ *         description: Template not found
+ */
+router.get("/:id", async (req, res) => {
+  try {
+    const userId = res.locals.user?.id;
+    if (!userId) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const id = req.params.id as string;
+    const template = platformTemplates.find((t) => t.id === id);
+
+    if (!template) {
+      return res.status(404).json({ error: "Platform template not found" });
+    }
+
+    return res.json({ success: true, template });
+  } catch (error) {
+    logger.error({ error: error as Error });
+    res.status(500).json({ error: "Failed to get platform template" });
+  }
+});
+
+export default router;

--- a/code/apps/dashboard/src/lib/api/platform-templates.ts
+++ b/code/apps/dashboard/src/lib/api/platform-templates.ts
@@ -1,0 +1,32 @@
+import { apiFetch } from "./core";
+
+export interface PlatformTemplateSummary {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  widthPx: number;
+  heightPx: number;
+  fields: string[];
+}
+
+export interface PlatformTemplate extends PlatformTemplateSummary {
+  html: string;
+}
+
+export async function getPlatformTemplates(): Promise<{
+  success: true;
+  templates: PlatformTemplateSummary[];
+}> {
+  return apiFetch<{ success: true; templates: PlatformTemplateSummary[] }>(
+    "/api/platform-templates",
+  );
+}
+
+export async function getPlatformTemplate(
+  id: string,
+): Promise<{ success: true; template: PlatformTemplate }> {
+  return apiFetch<{ success: true; template: PlatformTemplate }>(
+    `/api/platform-templates/${encodeURIComponent(id)}`,
+  );
+}

--- a/code/apps/dashboard/src/routeTree.gen.ts
+++ b/code/apps/dashboard/src/routeTree.gen.ts
@@ -19,6 +19,7 @@ import { Route as ProfileIndexRouteImport } from './routes/profile.index'
 import { Route as SetsIndexRouteImport } from './routes/sets.index'
 import { Route as SetsSetIdRouteImport } from './routes/sets.$setId'
 import { Route as TemplatesIndexRouteImport } from './routes/templates.index'
+import { Route as PlatformTemplatesIndexRouteImport } from './routes/platform-templates.index'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
@@ -70,6 +71,11 @@ const TemplatesIndexRoute = TemplatesIndexRouteImport.update({
   path: '/templates/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const PlatformTemplatesIndexRoute = PlatformTemplatesIndexRouteImport.update({
+  id: '/platform-templates/',
+  path: '/platform-templates/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -82,6 +88,7 @@ export interface FileRoutesByFullPath {
   '/profile/': typeof ProfileIndexRoute
   '/sets/': typeof SetsIndexRoute
   '/templates/': typeof TemplatesIndexRoute
+  '/platform-templates/': typeof PlatformTemplatesIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -94,6 +101,7 @@ export interface FileRoutesByTo {
   '/profile': typeof ProfileIndexRoute
   '/sets': typeof SetsIndexRoute
   '/templates': typeof TemplatesIndexRoute
+  '/platform-templates': typeof PlatformTemplatesIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -107,6 +115,7 @@ export interface FileRoutesById {
   '/profile/': typeof ProfileIndexRoute
   '/sets/': typeof SetsIndexRoute
   '/templates/': typeof TemplatesIndexRoute
+  '/platform-templates/': typeof PlatformTemplatesIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -121,6 +130,7 @@ export interface FileRouteTypes {
     | '/profile/'
     | '/sets/'
     | '/templates/'
+    | '/platform-templates/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -133,6 +143,7 @@ export interface FileRouteTypes {
     | '/profile'
     | '/sets'
     | '/templates'
+    | '/platform-templates'
   id:
     | '__root__'
     | '/'
@@ -145,6 +156,7 @@ export interface FileRouteTypes {
     | '/profile/'
     | '/sets/'
     | '/templates/'
+    | '/platform-templates/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -158,6 +170,7 @@ export interface RootRouteChildren {
   ProfileIndexRoute: typeof ProfileIndexRoute
   SetsIndexRoute: typeof SetsIndexRoute
   TemplatesIndexRoute: typeof TemplatesIndexRoute
+  PlatformTemplatesIndexRoute: typeof PlatformTemplatesIndexRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -232,6 +245,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof TemplatesIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/platform-templates/': {
+      id: '/platform-templates/'
+      path: '/platform-templates'
+      fullPath: '/platform-templates/'
+      preLoaderRoute: typeof PlatformTemplatesIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -246,6 +266,7 @@ const rootRouteChildren: RootRouteChildren = {
   ProfileIndexRoute: ProfileIndexRoute,
   SetsIndexRoute: SetsIndexRoute,
   TemplatesIndexRoute: TemplatesIndexRoute,
+  PlatformTemplatesIndexRoute: PlatformTemplatesIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/code/apps/dashboard/src/routes/__root.tsx
+++ b/code/apps/dashboard/src/routes/__root.tsx
@@ -34,6 +34,7 @@ const navItems = [
   { to: "/", label: "Dashboard" },
   { to: "/sets", label: "Sets" },
   { to: "/templates", label: "Templates" },
+  { to: "/platform-templates", label: "Platform" },
   { to: "/profile", label: "Profile" },
   { to: "/ai", label: "AI Studio" },
   { to: "/ai-logs", label: "AI Logs" },

--- a/code/apps/dashboard/src/routes/platform-templates.index.tsx
+++ b/code/apps/dashboard/src/routes/platform-templates.index.tsx
@@ -1,0 +1,212 @@
+import { useState } from "react";
+import { createFileRoute } from "@tanstack/react-router";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import {
+  getPlatformTemplates,
+  getPlatformTemplate,
+  type PlatformTemplate,
+  type PlatformTemplateSummary,
+} from "@/lib/api/platform-templates";
+
+export const Route = createFileRoute("/platform-templates/")({
+  component: PlatformTemplatesPage,
+});
+
+function PlatformTemplatesPage() {
+  const [previewId, setPreviewId] = useState<string | null>(null);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["platform-templates"],
+    queryFn: () => getPlatformTemplates(),
+  });
+
+  const copyMutation = useMutation({
+    mutationFn: async (template: PlatformTemplate) => {
+      const blob = new Blob([template.html], { type: "text/html" });
+      const file = new File([blob], `${template.name.replace(/\s+/g, "-").toLowerCase()}.html`, {
+        type: "text/html",
+      });
+      const formData = new FormData();
+      formData.append("template", file);
+      const response = await fetch("/api/template/upload", {
+        method: "POST",
+        body: formData,
+        credentials: "include",
+      });
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        throw new Error(
+          data && typeof data.error === "string" ? data.error : response.statusText,
+        );
+      }
+      return response.json();
+    },
+    onSuccess: (_data, template) => {
+      setCopiedId(template.id);
+      void queryClient.invalidateQueries({ queryKey: ["templates"] });
+      setTimeout(() => setCopiedId(null), 2000);
+    },
+  });
+
+  function handlePreview(template: PlatformTemplateSummary) {
+    setPreviewId(previewId === template.id ? null : template.id);
+  }
+
+  const categories = data
+    ? [...new Set(data.templates.map((t) => t.category))]
+    : [];
+
+  return (
+    <div className="flex flex-col gap-6 p-4 md:p-6">
+      <div>
+        <h1 className="text-xl font-semibold">Platform Templates</h1>
+        <p className="text-sm text-muted-foreground">
+          Curated templates for common use cases. Preview and copy them to your
+          collection to customize.
+        </p>
+      </div>
+
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading templates...</p>
+      ) : (
+        categories.map((category) => (
+          <div key={category}>
+            <h2 className="mb-3 text-sm font-medium text-muted-foreground">
+              {category}
+            </h2>
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {data?.templates
+                .filter((t) => t.category === category)
+                .map((template) => (
+                  <TemplateCard
+                    key={template.id}
+                    template={template}
+                    isPreviewOpen={previewId === template.id}
+                    onPreview={() => handlePreview(template)}
+                    onCopy={() => loadAndCopy(template.id)}
+                    isCopying={copyMutation.isPending && copyMutation.variables?.id === template.id}
+                    isCopied={copiedId === template.id}
+                  />
+                ))}
+            </div>
+          </div>
+        ))
+      )}
+    </div>
+  );
+
+  async function loadAndCopy(id: string) {
+    const result = await getPlatformTemplate(id);
+    copyMutation.mutate(result.template);
+  }
+}
+
+function TemplateCard({
+  template,
+  isPreviewOpen,
+  onPreview,
+  onCopy,
+  isCopying,
+  isCopied,
+}: {
+  template: PlatformTemplateSummary;
+  isPreviewOpen: boolean;
+  onPreview: () => void;
+  onCopy: () => void;
+  isCopying: boolean;
+  isCopied: boolean;
+}) {
+  return (
+    <Card className="overflow-hidden">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">{template.name}</CardTitle>
+        <CardDescription className="text-xs">
+          {template.description}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+          <span>
+            {template.widthPx} × {template.heightPx}
+          </span>
+          {template.fields.length > 0 && (
+            <span>· {template.fields.length} field{template.fields.length !== 1 ? "s" : ""}</span>
+          )}
+        </div>
+        {isPreviewOpen && (
+          <PreviewFrame
+            templateId={template.id}
+            width={template.widthPx}
+            height={template.heightPx}
+          />
+        )}
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" onClick={onPreview}>
+            {isPreviewOpen ? "Hide preview" : "Preview"}
+          </Button>
+          <Button
+            size="sm"
+            onClick={onCopy}
+            disabled={isCopying}
+          >
+            {isCopied ? "Copied!" : isCopying ? "Copying..." : "Copy to my templates"}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function PreviewFrame({
+  templateId,
+  width,
+  height,
+}: {
+  templateId: string;
+  width: number;
+  height: number;
+}) {
+  const { data, isLoading } = useQuery({
+    queryKey: ["platform-template", templateId],
+    queryFn: () => getPlatformTemplate(templateId),
+    staleTime: Infinity,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center rounded-md border bg-muted/30 p-4 text-xs text-muted-foreground">
+        Loading preview...
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const scale = Math.min(500 / width, 300 / height, 1);
+
+  return (
+    <div className="overflow-hidden rounded-md border">
+      <iframe
+        srcDoc={data.template.html}
+        title={`${templateId} preview`}
+        style={{
+          width: `${width * scale}px`,
+          height: `${height * scale}px`,
+          border: "none",
+          pointerEvents: "none",
+        }}
+        sandbox=""
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #15. Provides curated platform templates for common use cases (LinkedIn banner, Instagram post, Twitter/X header, email header, event banner), as optional guidance — users can preview and copy them into their own template collection.

## Changes

- **API** (`apps/api/src/platform-templates/templates.ts`): 5 curated platform templates with fixed pixel dimensions, `{{ profile.* }}` placeholder usage, inline CSS, no JS.
- **API routes** (`apps/api/src/routes/api/platform-templates.ts`):
  - `GET /api/platform-templates` — list templates (no HTML).
  - `GET /api/platform-templates/:id` — full template incl. HTML.
- **Dashboard** (`apps/dashboard/src/routes/platform-templates.index.tsx`): browse templates grouped by category, sandboxed iframe preview, `Copy to my templates` button posting to `POST /api/template/upload`. Nav link added in `__root.tsx`.

## Verification

- `apps/api` tests: 47 pass.
- `bun run check-types`: 5/5.
- Dashboard `typecheck`: clean.